### PR TITLE
Switch trigger from "pull_request" to "pull_request_target" in action usage

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -3,7 +3,7 @@ name: Comment Commands
 on:
   issue_comment:        # Handle comment commands
     types: [created]
-  pull_request:         # Handle renamed PRs
+  pull_request_target:  # Handle renamed PRs
     types: [edited]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ name: Repo Commands
 on:
   issue_comment:        # Handle comment commands
     types: [created]
-  pull_request:         # Handle renamed PRs
+  pull_request_target:  # Handle renamed PRs
     types: [edited]
 
 jobs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -9664,7 +9664,10 @@ const core = __nccwpck_require__(2186)
 const context = github.context
 
 const token = process.env.GITHUB_TOKEN || core.getInput('token')
-if (!token) throw new Error('No Github token was specified, please see the documentation for correct Action usage.')
+if (!token) {
+  console.error('No Github token was specified, please see the documentation for correct Action usage.')
+  process.exit()
+}
 const octokit = github.getOctokit(token)
 
 const getInput = (name, required = false) => core.getInput(name, { required })

--- a/src/github.js
+++ b/src/github.js
@@ -44,7 +44,10 @@ const core = require('@actions/core')
 const context = github.context
 
 const token = process.env.GITHUB_TOKEN || core.getInput('token')
-if (!token) throw new Error('No Github token was specified, please see the documentation for correct Action usage.')
+if (!token) {
+  console.error('No Github token was specified, please see the documentation for correct Action usage.')
+  process.exit()
+}
 const octokit = github.getOctokit(token)
 
 const getInput = (name, required = false) => core.getInput(name, { required })


### PR DESCRIPTION
Fixes issue where when the trigger was a `pull_request` event, that no [Github token would be provided](https://github.com/PrismarineJS/minecraft-data/actions/runs/5496348681/jobs/10016316401) if the user didn't have write access. Seems like this is a intentional per https://github.com/actions/checkout/issues/298#issuecomment-809285783 and https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git.

Instead it seems the pull_request_target event should be used instead per https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/:
> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.

Also updates the Action to exit as success with an error message instead of failing the job if no token is provided. This only affects PR triggers (which are currently just used to handle renamed release PRs) and not normal comment command triggers.