### PR TITLE
Add a /mergeonpass command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,5 @@ Commands can be enabled/disabled by setting the `/$command.enabled` property to 
 * /fixlint
   * Run a lint fix command on the current PR, then push the update to the PR
   * [Example trigger](https://github.com/PrismarineJS/prismarine-repo-actions/pull/6)
-
+* `/mergeonpass [retries] [mode: squash (default), merge, rebase]\n[custom commit message]`
+  * Merge a pull request 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ Commands can be enabled/disabled by setting the `/$command.enabled` property to 
     <td>What command to use to fix the lint</td>
   </tr>
   <tr>
+    <td>/mergeonpass.enabled</td>
+    <td><code>true</code></td>
+    <td>Whether or not to enable the `/mergeonpass` command</td>
+  </tr>
+  <tr>
+    <td>/mergeonpass.maxWaitTime</td>
+    <td><code>600000 (1m)</code></td>
+    <td>How long to wait in milliseconds for the PR checks to pass (after retries) before giving up</td>
+  </tr>
+  <tr>
+    <td>/mergeonpass.defaultRetries</td>
+    <td><code>1</code></td>
+    <td>How many times to retry the PR checks on failure when waiting on merge, if the user does not specify in argument</td>
+  </tr>
+  <tr>
+    <td>/mergeonpass.defaultMode</td>
+    <td><code>squash</code></td>
+    <td>What merge mode to use by default, options are { squash, merge, rebase }, if the user does not specify in argument</td>
+  </tr>
+  <tr>
     <td>llm-services-repo</td>
     <td><code>$currentOrganization/llm-services</code></td>
     <td>What repository to use to send LLM requests to via dispatch. For example, `PrismarineJS/llm-services`. Defaults to the triggering repo's org's `llm-services` repo.</td>
@@ -99,5 +119,11 @@ Commands can be enabled/disabled by setting the `/$command.enabled` property to 
 * /fixlint
   * Run a lint fix command on the current PR, then push the update to the PR
   * [Example trigger](https://github.com/PrismarineJS/prismarine-repo-actions/pull/6)
-* `/mergeonpass [retries] [mode: squash (default), merge, rebase]\n[custom commit message]`
-  * Merge a pull request 
+* `/mergeonpass [retries (default: 1)] [mode: squash (default), merge, rebase]\n[custom commit message]`
+  * Merge a pull request after tests pass, with n retries of failed tests.
+  * Merge a PR with 3 retries with standard merge mode, with the custom merge commit message "Merge this PR"
+    ```
+    /mergeonpass 3 merge
+    Merge this PR
+    ```
+  * [Example trigger](https://github.com/extremeheat/gh-helpers/pull/25)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^6.0.0",
-    "gh-helpers": "github:extremeheat/gh-helpers#merge-pr"
+    "gh-helpers": "^0.3.1"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^6.0.0",
-    "gh-helpers": "^0.3.0"
+    "gh-helpers": "github:extremeheat/gh-helpers#merge-pr"
   },
   "standard": {
     "ignore": [

--- a/src/index.js
+++ b/src/index.js
@@ -255,17 +255,19 @@ const commands = {
    * @this {import('gh-helpers').HookOnRepoCommentPayload}
    */
   async mergeonpass ([], sargs) {
-    // wait for upto 10 minutes for the checks to pass
-    const MAX_WAIT = 10 * 60 * 1000
+    // wait for upto 10 minutes for the checks to pass by default
+    const MAX_WAIT = github.getInput('/mergeonpass.maxWaitTime') || 10 * 60 * 1000
+    const DEFAULT_RETRIES = github.getInput('/mergeonpass.defaultRetries') || 1
+    const DEFAULT_MODE = github.getInput('/mergeonpass.defaultMode') || 'squash'
     if (this.type !== 'pull') return
-    let retries = 0
+    let retries = DEFAULT_RETRIES
     /** @type {'squash' | 'merge' | 'rebase'} */
-    let mode = 'squash'
+    let mode = DEFAULT_MODE
     const [first, message] = sargs.split('\n')
     if (first) {
       const [_retries, _mode] = first.split(' ')
-      retries = parseInt(_retries) || 0
-      mode = _mode || 'squash'
+      retries = parseInt(_retries) || retries
+      mode = _mode || mode
       if (!['squash', 'merge', 'rebase'].includes(mode)) {
         return raise('Invalid merge mode, must be one of { squash, merge, rebase } set')
       }
@@ -273,15 +275,21 @@ const commands = {
     const prInfo = await github.getPullRequest(this.issue.number)
     const checks = await github.getPullRequestChecks(prInfo.number)
     console.log('PR Checks', checks)
+    if (!checks.length) {
+      // No checks found, sometimes the checks are not yet started. So wait a bit before below code runs.
+      await new Promise(resolve => setTimeout(resolve, 5000))
+    }
 
     do {
       const waited = await github.waitForPullRequestChecks(prInfo.number, MAX_WAIT)
       console.log('Waited for checks', waited)
       if (waited.every(e => e.conclusion === 'success')) {
         return await github.mergePullRequest(prInfo.number, { method: mode, title: message })
-      } else {
+      } else if (waited.some(e => e.conclusion === 'failure')) {
         await github.retryPullRequestChecks(prInfo.number)
         console.log('Retrying checks', retries)
+      } else {
+        return raise(`Sorry, I couldn't merge the PR because some checks are in an unknown state.\n<pre>${JSON.stringify(waited, null, 2)}</pre>`)
       }
     } while (retries-- > 0)
 


### PR DESCRIPTION
Add a /mergeonpass command to automatically merge a PR once tests have passed with customizable amount of re-runs on failure (by default waiting upto 10min)

Doc:

* `/mergeonpass [retries (default: 1)] [mode: squash (default), merge, rebase]\n[custom commit message]`
  * Merge a pull request after tests pass, with n retries of failed tests.
  * Merge a PR with 3 retries with standard merge mode, with the custom merge commit message "Merge this PR"
    ```
    /mergeonpass 3 merge
    Merge this PR
    ```
  * [Example trigger](https://github.com/extremeheat/gh-helpers/pull/25)
