### PR TITLE
Bump /mergeonpass default wait time and message on fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Commands can be enabled/disabled by setting the `/$command.enabled` property to 
   </tr>
   <tr>
     <td>/mergeonpass.maxWaitTime</td>
-    <td><code>600000 (1m)</code></td>
+    <td><code>600000</code> (20 min)</td>
     <td>How long to wait in milliseconds for the PR checks to pass (after retries) before giving up</td>
   </tr>
   <tr>

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,7 @@ const commands = {
    */
   async mergeonpass ([], sargs) {
     // wait for upto 10 minutes for the checks to pass by default
-    const MAX_WAIT = github.getInput('/mergeonpass.maxWaitTime') || 10 * 60 * 1000
+    const MAX_WAIT = github.getInput('/mergeonpass.maxWaitTime') || 20 * 60 * 1000
     const DEFAULT_RETRIES = github.getInput('/mergeonpass.defaultRetries') || 1
     const DEFAULT_MODE = github.getInput('/mergeonpass.defaultMode') || 'squash'
     if (this.type !== 'pull') return
@@ -292,6 +292,8 @@ const commands = {
         return raise(`Sorry, I couldn't merge the PR because some checks are in an unknown state.\n<pre>${JSON.stringify(waited, null, 2)}</pre>`)
       }
     } while (retries-- > 0)
+
+    return raise("Sorry, I couldn't merge the PR because some checks are still failing.")
 
     async function raise (message) {
       await github.comment(this.issue.number, message)


### PR DESCRIPTION
Update default timeout to 20 min to account for retries